### PR TITLE
feat(web): Chronicle Layer 2 registry pilot (library)

### DIFF
--- a/apps/web/src/v0/presence/ChronicleEntityView.tsx
+++ b/apps/web/src/v0/presence/ChronicleEntityView.tsx
@@ -1,0 +1,72 @@
+"use client"
+
+/**
+ * Chronicle Layer 2 — thin registry router.
+ *
+ * Looks up entity kind in CHRONICLE_ENTITY_REGISTRY and renders focus or config.
+ * Unregistered kinds fall through to KeeperPresence via ChroniclePresenceView.
+ */
+
+import * as React from "react"
+import {
+  getChronicleEntitySpec,
+  isRegistryEntityKind,
+  type ChronicleEntityFocusProps,
+} from "./chronicleEntityRegistry"
+import type { PresenceLayout } from "./types"
+
+export interface ChronicleEntityViewProps {
+  entityKind: string
+  entityId: string
+  domainId: string
+  layout?: PresenceLayout
+  record?: Record<string, unknown>
+  onLabelResolved?: (label: string) => void
+}
+
+export function ChronicleEntityView({
+  entityKind,
+  entityId,
+  domainId,
+  layout = "focus",
+  record: seedRecord,
+  onLabelResolved,
+}: ChronicleEntityViewProps) {
+  if (!isRegistryEntityKind(entityKind)) {
+    return null
+  }
+
+  const spec = getChronicleEntitySpec(entityKind)
+  const [record, setRecord] = React.useState<Record<string, unknown>>(seedRecord ?? {})
+
+  React.useEffect(() => {
+    if (seedRecord && Object.keys(seedRecord).length > 0) {
+      setRecord(seedRecord)
+      return
+    }
+
+    let cancelled = false
+    void spec.fetchRecord(entityId).then((row) => {
+      if (!cancelled && row) {
+        setRecord(row)
+      }
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [entityId, seedRecord, spec])
+
+  const focusProps: ChronicleEntityFocusProps = {
+    objectId: entityId,
+    domainId,
+    record,
+    onLabelResolved,
+  }
+
+  // Library (pilot): config is orchestrated inside focus via coverMode.
+  const Focus = spec.focus
+  return <Focus {...focusProps} />
+}
+
+export { isRegistryEntityKind } from "./chronicleEntityRegistry"

--- a/apps/web/src/v0/presence/ChroniclePresenceView.tsx
+++ b/apps/web/src/v0/presence/ChroniclePresenceView.tsx
@@ -12,6 +12,7 @@
 import * as React from "react"
 import { KeeperPresence } from "./KeeperPresence"
 import { SoleMemoryPresence } from "./SoleMemoryPresence"
+import { ChronicleEntityView, isRegistryEntityKind } from "./ChronicleEntityView"
 import type { DensityLevel } from "./KeeperPresenceDefaults"
 import type { PresenceLayout } from "./types"
 import type { PresentName, RenderContext } from "../presents/types"
@@ -81,6 +82,23 @@ export function ChroniclePresenceView({
       <ChronicleTreatmentShell treatment={treatment}>{soleBody}</ChronicleTreatmentShell>
     ) : (
       soleBody
+    )
+  }
+
+  if (isRegistryEntityKind(objectType)) {
+    const registryBody = (
+      <ChronicleEntityView
+        entityKind={objectType}
+        entityId={objectId}
+        domainId={domainId}
+        layout={layout}
+        onLabelResolved={onLabelResolved}
+      />
+    )
+    return treatment ? (
+      <ChronicleTreatmentShell treatment={treatment}>{registryBody}</ChronicleTreatmentShell>
+    ) : (
+      registryBody
     )
   }
 

--- a/apps/web/src/v0/presence/KeeperPresence.tsx
+++ b/apps/web/src/v0/presence/KeeperPresence.tsx
@@ -985,7 +985,6 @@ export function KeeperPresence({
   const skipPresenceSchemaFetch =
     (objectType === "key" && layout === "focus") ||
     (objectType === "capability" && layout === "focus") ||
-    (objectType === "library" && layout === "focus") ||
     (objectType === "keeper" && layout === "focus") ||
     (objectType === "agent" && layout === "focus") ||
     (objectType === "journey" && layout === "focus") ||

--- a/apps/web/src/v0/presence/KeeperPresence.tsx
+++ b/apps/web/src/v0/presence/KeeperPresence.tsx
@@ -40,7 +40,6 @@ import { DomainFocusPresence } from "./cover/DomainFocusPresence"
 import { KeyFocusPresence } from "./cover/KeyFocusPresence"
 import { CapabilityFocusPresence } from "./cover/CapabilityFocusPresence"
 import { KeeperFocusPresence } from "./cover/KeeperFocusPresence"
-import { LibraryItemFocusPresence } from "./cover/LibraryItemFocusPresence"
 import { IntegrationFocusPresence } from "./cover/IntegrationFocusPresence"
 import { KipApi, type ModelProvider } from "../../lib/kipApi"
 import { parseChroniclePatchFieldErrors } from "./chronicleConfig/chroniclePatch"
@@ -1719,17 +1718,6 @@ function KeeperPresenceSurface({
   if (objectType === "capability" && layout === "focus" && record) {
     return (
       <CapabilityFocusPresence
-        objectId={objectId}
-        domainId={domainId}
-        record={record}
-        onLabelResolved={onLabelResolved}
-      />
-    )
-  }
-
-  if (objectType === "library" && layout === "focus" && record) {
-    return (
-      <LibraryItemFocusPresence
         objectId={objectId}
         domainId={domainId}
         record={record}

--- a/apps/web/src/v0/presence/README.md
+++ b/apps/web/src/v0/presence/README.md
@@ -15,7 +15,9 @@ Schema-driven Chronicle rendering layer. Resolves and applies per-domain, per-ob
 - `AgentPromptsSection.tsx` — point-based lens/composed prompt editor (agents)
 - `promptPoints.ts` — parse/serialize prompt strings ↔ editable points
 - `presenceEnrichment.ts` — fetches records and resolves journey context, paths, sessions per object type
-- `ChroniclePresenceView.tsx` — thin Chronicle wrapper; `soleMemory` only special case; `service` and `key` flow through `KeeperPresence`
+- `ChroniclePresenceView.tsx` — thin Chronicle wrapper; registry kinds + `soleMemory` before `KeeperPresence`
+- `chronicleEntityRegistry.ts` — Layer 2 entity registry (`CHRONICLE_ENTITY_REGISTRY`; pilot: library)
+- `ChronicleEntityView.tsx` — registry lookup router; renders focus/config per kind
 - `integrationChronicle/` — Hero, Status Strip, Primary Feed, Actions; unconnected Connect via Nango
 - `chronicleConfig/` — universal Config Mode save infrastructure (`useChronicleConfig`, save bar, config shell)
 - `cover/DomainFocusPresence.tsx` — Domain Cover + Config orchestration
@@ -48,7 +50,7 @@ Enrichment (Domain Board instincts):
 
 Props: one catalog (`propsCatalog.ts`), one persistence path (`frameProps.ts` → `PUT /api/domains/:domainId/board-data`), `normalizeProps()` at every boundary. Legacy Studio sidebar and `DesignBoardFrameDetail` Props tab are orphaned — not deleted.
 
-Chronicle routes exclusively through `ChroniclePresenceView` → `KeeperPresence`. No board-specific panel renderers.
+Chronicle routes through `ChroniclePresenceView` → registry (`ChronicleEntityView`) or `KeeperPresence` fallback. No board-specific panel renderers.
 
 Presents (Theatre.js): when `layout="focus"`, KeeperPresence plays a Present sequence via `PresentMotionProvider`. `present` defaults from object type (`domain→cover`, `journey→journey`, `moment→moment`, else `slide`). See `../presents/README.md`.
 
@@ -92,7 +94,7 @@ Presents (Theatre.js): when `layout="focus"`, KeeperPresence plays a Present seq
 - `LibraryItemConfigPresence` — editable metadata + assignment selects; `onSaved` → `bumpLibraryNav`
 - `declarationChronicle.tsx`: `variant="library"` with `definition` + `agent_perspective` blocks
 - `libraryItemCoverSchema.ts` + `libraryNavUtils.ts`: shared `libraryItemChronicleTitle()` for Cover and Nav
-- `KeeperPresence`: `library` focus branch + `skipPresenceSchemaFetch`
+- `KeeperPresence`: `library` focus branch removed — routes via `chronicleEntityRegistry` (2026-07-13)
 - `presenceEnrichment.ts`: `fetchPresenceRecord` case for `library`
 - `chroniclePatch.ts`: `library` → `PATCH /api/library-items/:id`
 

--- a/apps/web/src/v0/presence/README.md
+++ b/apps/web/src/v0/presence/README.md
@@ -60,6 +60,10 @@ Presents (Theatre.js): when `layout="focus"`, KeeperPresence plays a Present seq
 
 ## 📆 Update Log
 
+### 2026-07-13 — Chronicle Layer 2 registry pilot (library)
+- `chronicleEntityRegistry.ts` + `ChronicleEntityView.tsx` — registry lookup replaces library if-branch in `KeeperPresence`
+- `ChroniclePresenceView` routes registered kinds through registry before legacy fallback
+
 ### 2026-07-07 — Configure load perf + Treatment fields
 - `KeeperPresence` stale-while-revalidate — existing Chronicle content stays visible during background refresh
 - Domain enrichment accepts shell `prefetchedFrame` to skip duplicate `GET /frame` on Configure open

--- a/apps/web/src/v0/presence/chronicleEntityRegistry.ts
+++ b/apps/web/src/v0/presence/chronicleEntityRegistry.ts
@@ -1,0 +1,75 @@
+"use client"
+
+/**
+ * Chronicle Layer 2 — entity registry (pilot: library only).
+ *
+ * New EntityKinds register here instead of adding branches to KeeperPresence.
+ * See docs/chronicle-document-architecture.md.
+ */
+
+import type * as React from "react"
+import { apiFetch } from "../../lib/api"
+import type { ChronicleEntityKind } from "./chronicleConfig/types"
+import { resolveChroniclePatchEndpoint } from "./chronicleConfig/chroniclePatch"
+import { LibraryItemFocusPresence } from "./cover/LibraryItemFocusPresence"
+import { libraryItemCoverSchema } from "./cover/schemas/libraryItemCoverSchema"
+import type { EntityCoverSchema } from "./cover/coverTypes"
+import { LibraryItemConfigPresence } from "./integrationChronicle/LibraryItemConfigPresence"
+import { resolveLibraryChronicleBlocks } from "./integrationChronicle/resolveChronicleDeclaration"
+import {
+  libraryItemChronicleTitle,
+  type LibraryNavRow,
+} from "./integrationChronicle/libraryNavUtils"
+
+/** Props passed from ChronicleEntityView to registry focus components. */
+export interface ChronicleEntityFocusProps {
+  objectId: string
+  domainId: string
+  record: Record<string, unknown>
+  onLabelResolved?: (label: string) => void
+}
+
+export interface ChronicleEntitySpec {
+  /** Focus mode orchestrator (Cover ↔ Config). */
+  focus: React.ComponentType<ChronicleEntityFocusProps>
+  /** Config mode component — may be orchestrated inside focus for some kinds. */
+  config?: React.ComponentType<ChronicleEntityFocusProps>
+  fetchRecord: (entityId: string) => Promise<Record<string, unknown> | null>
+  resolveBlocks?: (dbBlocks: string[] | null | undefined) => string[]
+  coverSchema?: EntityCoverSchema<Record<string, unknown>>
+  patchEndpoint: (entityId: string, domainId: string) => string
+  navLabel: (row: Record<string, unknown>) => string
+}
+
+async function fetchLibraryRecord(entityId: string): Promise<Record<string, unknown> | null> {
+  try {
+    const row = await apiFetch(`/api/library-items/${encodeURIComponent(entityId)}`)
+    return row as Record<string, unknown>
+  } catch {
+    return null
+  }
+}
+
+export const CHRONICLE_ENTITY_REGISTRY = {
+  library: {
+    focus: LibraryItemFocusPresence,
+    // Orchestrated inside focus today; listed for registry completeness.
+    config: LibraryItemConfigPresence as unknown as React.ComponentType<ChronicleEntityFocusProps>,
+    fetchRecord: fetchLibraryRecord,
+    resolveBlocks: resolveLibraryChronicleBlocks,
+    coverSchema: libraryItemCoverSchema as EntityCoverSchema<Record<string, unknown>>,
+    patchEndpoint: (entityId, domainId) =>
+      resolveChroniclePatchEndpoint("library", entityId, domainId),
+    navLabel: (row) => libraryItemChronicleTitle(row as Pick<LibraryNavRow, "source_type" | "source_ref" | "display_label">),
+  },
+} as const satisfies Partial<Record<ChronicleEntityKind, ChronicleEntitySpec>>
+
+export type RegistryEntityKind = keyof typeof CHRONICLE_ENTITY_REGISTRY
+
+export function isRegistryEntityKind(kind: string): kind is RegistryEntityKind {
+  return kind in CHRONICLE_ENTITY_REGISTRY
+}
+
+export function getChronicleEntitySpec(kind: RegistryEntityKind): ChronicleEntitySpec {
+  return CHRONICLE_ENTITY_REGISTRY[kind]
+}

--- a/docs/modules/apps/web/src/v0/presence/README.md
+++ b/docs/modules/apps/web/src/v0/presence/README.md
@@ -15,7 +15,9 @@ Schema-driven Chronicle rendering layer. Resolves and applies per-domain, per-ob
 - `AgentPromptsSection.tsx` — point-based lens/composed prompt editor (agents)
 - `promptPoints.ts` — parse/serialize prompt strings ↔ editable points
 - `presenceEnrichment.ts` — fetches records and resolves journey context, paths, sessions per object type
-- `ChroniclePresenceView.tsx` — thin Chronicle wrapper; `soleMemory` only special case; `service` and `key` flow through `KeeperPresence`
+- `ChroniclePresenceView.tsx` — thin Chronicle wrapper; registry kinds + `soleMemory` before `KeeperPresence`
+- `chronicleEntityRegistry.ts` — Layer 2 entity registry (`CHRONICLE_ENTITY_REGISTRY`; pilot: library)
+- `ChronicleEntityView.tsx` — registry lookup router; renders focus/config per kind
 - `integrationChronicle/` — Hero, Status Strip, Primary Feed, Actions; unconnected Connect via Nango
 - `chronicleConfig/` — universal Config Mode save infrastructure (`useChronicleConfig`, save bar, config shell)
 - `cover/DomainFocusPresence.tsx` — Domain Cover + Config orchestration
@@ -48,7 +50,7 @@ Enrichment (Domain Board instincts):
 
 Props: one catalog (`propsCatalog.ts`), one persistence path (`frameProps.ts` → `PUT /api/domains/:domainId/board-data`), `normalizeProps()` at every boundary. Legacy Studio sidebar and `DesignBoardFrameDetail` Props tab are orphaned — not deleted.
 
-Chronicle routes exclusively through `ChroniclePresenceView` → `KeeperPresence`. No board-specific panel renderers.
+Chronicle routes through `ChroniclePresenceView` → registry (`ChronicleEntityView`) or `KeeperPresence` fallback. No board-specific panel renderers.
 
 Presents (Theatre.js): when `layout="focus"`, KeeperPresence plays a Present sequence via `PresentMotionProvider`. `present` defaults from object type (`domain→cover`, `journey→journey`, `moment→moment`, else `slide`). See `../presents/README.md`.
 
@@ -92,7 +94,7 @@ Presents (Theatre.js): when `layout="focus"`, KeeperPresence plays a Present seq
 - `LibraryItemConfigPresence` — editable metadata + assignment selects; `onSaved` → `bumpLibraryNav`
 - `declarationChronicle.tsx`: `variant="library"` with `definition` + `agent_perspective` blocks
 - `libraryItemCoverSchema.ts` + `libraryNavUtils.ts`: shared `libraryItemChronicleTitle()` for Cover and Nav
-- `KeeperPresence`: `library` focus branch + `skipPresenceSchemaFetch`
+- `KeeperPresence`: `library` focus branch removed — routes via `chronicleEntityRegistry` (2026-07-13)
 - `presenceEnrichment.ts`: `fetchPresenceRecord` case for `library`
 - `chroniclePatch.ts`: `library` → `PATCH /api/library-items/:id`
 

--- a/docs/modules/apps/web/src/v0/presence/README.md
+++ b/docs/modules/apps/web/src/v0/presence/README.md
@@ -60,6 +60,10 @@ Presents (Theatre.js): when `layout="focus"`, KeeperPresence plays a Present seq
 
 ## 📆 Update Log
 
+### 2026-07-13 — Chronicle Layer 2 registry pilot (library)
+- `chronicleEntityRegistry.ts` + `ChronicleEntityView.tsx` — registry lookup replaces library if-branch in `KeeperPresence`
+- `ChroniclePresenceView` routes registered kinds through registry before legacy fallback
+
 ### 2026-07-07 — Configure load perf + Treatment fields
 - `KeeperPresence` stale-while-revalidate — existing Chronicle content stays visible during background refresh
 - Domain enrichment accepts shell `prefetchedFrame` to skip duplicate `GET /frame` on Configure open


### PR DESCRIPTION
## Summary
- Adds `chronicleEntityRegistry.ts` with `ChronicleEntitySpec` and a library-only `CHRONICLE_ENTITY_REGISTRY`
- Adds thin `ChronicleEntityView` router; `ChroniclePresenceView` uses registry for library before `KeeperPresence`
- Removes library focus branch and `skipPresenceSchemaFetch` entry from `KeeperPresence` (registry is the default path)

Per `docs/chronicle-document-architecture.md` — Layer 2 pilot; other EntityKinds remain on KeeperPresence fallback.

## Test plan
- [ ] Open Universal Board at `?board=domain`, select a Library item in Nav
- [ ] Confirm Chronicle shows library cover, declaration blocks, and Configure → Config save
- [ ] Confirm other EntityKinds (journey, agent, key) still render via KeeperPresence
- [ ] Run `pnpm run quick:web` (no new errors in presence registry files)